### PR TITLE
SMK-1394: Infinite loop on close connection

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -353,6 +353,9 @@ class StreamIO extends AbstractIO
             fclose($this->sock);
         }
         $this->sock = null;
+        // Reset last_read and last_write
+        $this->last_read = null;
+        $this->last_write = null;
     }
 
     /**


### PR DESCRIPTION
This is affecting consumers when it takes more than 2*heartbeat time to process a message.
When trying to close the connection, library will:
* check the heartbeat
* detect that it passed more than 2*times the heartbeat value without receiving anything
* considers that server has gone away and tries to reconnect
* after reconnecting as it is not clearing internal variables with time of last read, it will check the heartbeat again and try to reconnect again in loop.

There are already issues on the library's github: https://github.com/php-amqplib/php-amqplib/issues/309 and https://github.com/php-amqplib/php-amqplib/issues/413

> Release patch version: 2.6.2

cc @smarkio/developers 